### PR TITLE
fix: improve match status type safety and relax next match filter

### DIFF
--- a/layers/shared/entities/Match.ts
+++ b/layers/shared/entities/Match.ts
@@ -37,9 +37,9 @@ export class Match {
 
   get status() {
     if (!isUndefined(this.awayGoals) && !isUndefined(this.homeGoals)) {
-      return { label: 'Finalizada', color: 'success', icon: 'i-lucide-check-circle' }
+      return { label: 'Finalizada', color: 'success' as const, icon: 'i-lucide-check-circle' }
     }
 
-    return { label: 'Não iniciada', color: 'neutral', icon: 'i-lucide-pause' }
+    return { label: 'Não iniciada', color: 'neutral' as const, icon: 'i-lucide-pause' }
   }
 }

--- a/layers/standings/application/stores/Matches.store.ts
+++ b/layers/standings/application/stores/Matches.store.ts
@@ -15,7 +15,7 @@ export const useMatchesStore = defineStore('matches', () => {
   }
 
   const nextMatch = computed(() => {
-    return matches.value.find(match => !match.isFinished && !match.isPostponed && match.isThisWeek)
+    return matches.value.find(match => !match.isFinished && !match.isPostponed)
   })
 
   const notPostponedMatches = computed(() => matches.value.filter(match => !match.isPostponed))


### PR DESCRIPTION
## Summary
- Use `as const` for match status color literals to ensure proper TypeScript type inference
- Remove `isThisWeek` constraint from `nextMatch` computed so it always finds the next upcoming match regardless of week

## Test plan
- [ ] Verify match status badges render correctly with proper color types
- [ ] Verify `nextMatch` returns the correct upcoming match even outside the current week

🤖 Generated with [Claude Code](https://claude.com/claude-code)